### PR TITLE
Make the list of supported cameras sorted

### DIFF
--- a/CAMERAS.md
+++ b/CAMERAS.md
@@ -1,41 +1,94 @@
+
+
+
 The following cameras are currently supported, as of Camera Live Build 10:
 
-    EOS M200
-    EOS M6 Mark II
-    EOS 90D
-    PowerShot G7X Mark III
-    PowerShot G5X Mark II
-    EOS Kiss X10 / EOS Rebel SL3 / EOS 250D / EOS 200D II EOS RP
-    PowerShot SX70 HS
-    EOS R
-    EOS Kiss M / EOS M50
-    EOS Kiss X90 / EOS REBEL T7 / EOS 2000D / EOS 1500D EOS REBEL T100/EOS 4000D / EOS 3000D
-    EOS 6D Mark II
-    EOS Kiss X9 / EOS Rebel SL2 / EOS 200D
-    EOS Kiss X9i / EOS Rebel T7i / EOS 800D
-    EOS 9000D / EOS 77D
-    EOS 5D Mark IV
+    EOS 1000D
+    EOS 100D
+    EOS 1100D
+    EOS 1200D
+    EOS 1300D
+    EOS 1500D
+    EOS-1D C
+    EOS-1D Mark III
+    EOS-1D Mark IV
+    EOS-1Ds Mark III
+    EOS-1D X
     EOS-1D X Mark II
-    EOS 80D
-    EOS Kiss X80 / EOS Rebel T6 / EOS 1300D
+    EOS 2000D
+    EOS 200D
+    EOS 200D II
+    EOS 250D
+    EOS 3000D
+    EOS 4000D
+    EOS 40D
+    EOS 450D
+    EOS 500D
+    EOS 50D
+    EOS 550D
+    EOS 5D Mark II
+    EOS 5D Mark III
+    EOS 5D Mark IV
     EOS 5DS
     EOS 5DS R
-    EOS 8000D / EOS REBEL T6sEOS 760D
-    EOS Kiss X8i / EOS REBEL T6i / EOS 750D
-    EOS 7D Mark II
-    EOS Kiss X70/EOS 1200D/EOS REBEL T5/EOS Hi
-    EOS 70D
-    EOS Kiss X7 / EOS 100D / EOS REBEL SL1
-    EOS Kiss X7i / EOS 700D / EOS REBEL T5i
-    EOS-1D C
+    EOS 600D
+    EOS 60D
+    EOS 650D
     EOS 6D
-    EOS Kiss X6i / EOS 650D / EOS REBEL T4i EOS-1D X
-    EOS 5D Mark III
-    EOS Kiss X50 / EOS REBEL T3 / EOS 1100D EOS Kiss X5 / EOS REBEL T3i / EOS 600D EOS 60D
-    EOS Kiss X4 / EOS REBEL T2i / EOS 550D EOS-1D Mark IV
+    EOS 6D Mark II
+    EOS 700D
+    EOS 70D
+    EOS 750D
+    EOS 760D
+    EOS 77D
     EOS 7D
-    EOS Kiss X3 / EOS REBEL T1i / EOS 500D EOS 5D Mark II
-    EOS 50D
-    EOS DIGITAL REBEL XS / 1000D/ KISS F EOS DIGITAL REBEL Xsi / 450D / Kiss X2 EOS-1Ds Mark III
-    EOS 40D
-    EOS-1D Mark III
+    EOS 7D Mark II
+    EOS 8000D
+    EOS 800D
+    EOS 80D
+    EOS 9000D
+    EOS 90D
+    EOS DIGITAL REBEL XS
+    EOS DIGITAL REBEL Xsi
+    EOS Hi
+    EOS KISS F
+    EOS Kiss M
+    EOS Kiss X10
+    EOS Kiss X2
+    EOS Kiss X3
+    EOS Kiss X4
+    EOS Kiss X5
+    EOS Kiss X50
+    EOS Kiss X6i
+    EOS Kiss X7
+    EOS Kiss X70
+    EOS Kiss X7i
+    EOS Kiss X80
+    EOS Kiss X8i
+    EOS Kiss X9
+    EOS Kiss X90
+    EOS Kiss X9i
+    EOS M200
+    EOS M50
+    EOS M6 Mark II
+    EOS R
+    EOS REBEL SL1
+    EOS Rebel SL2
+    EOS Rebel SL3
+    EOS REBEL T100
+    EOS REBEL T1i
+    EOS REBEL T2i
+    EOS REBEL T3
+    EOS REBEL T3i
+    EOS REBEL T4i
+    EOS REBEL T5
+    EOS REBEL T5i
+    EOS Rebel T6
+    EOS REBEL T6i
+    EOS REBEL T6s
+    EOS REBEL T7
+    EOS Rebel T7i
+    EOS RP
+    PowerShot G5X Mark II
+    PowerShot G7X Mark III
+    PowerShot SX70 HS


### PR DESCRIPTION
Since most people will be scanning this list for their camera, it should be easy to do so:
Each line should contain only one name and be in sorted order. This is sorted using Mac's /bin/sort.